### PR TITLE
fix/186 sovrapposizione evento senza immagine

### DIFF
--- a/styles/mobile.css
+++ b/styles/mobile.css
@@ -332,7 +332,7 @@ footer .logo {
 
 #evento-home {
     padding: 0;
-    background: repeating-linear-gradient( 45deg, var(--colorAccent), var(--colorAccent) 2px, rgba(255, 255, 255, 0) 2px, rgba(255, 255, 255, 0) 10px);
+    background: repeating-linear-gradient(45deg, var(--colorAccent), var(--colorAccent) 2px, rgba(255, 255, 255, 0) 2px, rgba(255, 255, 255, 0) 10px);
 }
 
 #evento-home::before {
@@ -520,10 +520,14 @@ label {
 
 #evento-box img {
     width: 100%;
+    position: relative;
+    top: unset;
 }
 
 #evento-info {
     width: 100%;
+    position: relative;
+    top: unset;
     gap: 0 1em;
     box-sizing: border-box;
     padding: 2.5em 0;

--- a/styles/style.css
+++ b/styles/style.css
@@ -24,7 +24,7 @@
 }
 
 @media screen and (min-width: 2560px) {
-     :root {
+    :root {
         --widthMax: 1800px;
     }
 }
@@ -861,13 +861,21 @@ p.eventiMessaggio {
 }
 
 #evento-box img {
+    height: fit-content;
     width: 46%;
+    position: sticky;
+    top: 4em;
+    object-fit: contain;
+    border: 1px solid var(--colorAccent);
+    /* padding: 1em; */
 }
 
 #evento-info {
-    position: relative;
+    height: fit-content;
     width: 46%;
-    max-height: 60vh;
+    position: sticky;
+    top: 4em;
+    padding-block: 2.5em;
     display: grid;
     grid-template-columns: auto 1fr;
     gap: 1em 2em;
@@ -875,30 +883,32 @@ p.eventiMessaggio {
     align-self: stretch;
 }
 
-#evento-info::before {
+#evento-info::before,
+#evento-info::after {
     content: '';
     position: absolute;
-    top: 0;
     left: 0;
     height: 1.5em;
     width: 100%;
     box-sizing: border-box;
+}
+
+#evento-info::before {
+    top: 0;
     background: repeating-linear-gradient(45deg, var(--colorAccent), var(--colorAccent) 2px, rgb(255 0 0 / 0%) 2px, rgba(255, 255, 255, 0) 10px);
 }
 
 #evento-info::after {
-    content: '';
-    position: absolute;
     bottom: 0;
-    left: 0;
-    height: 1.5em;
-    width: 100%;
-    box-sizing: border-box;
     background: repeating-linear-gradient(45deg, var(--colorAccent), var(--colorAccent) 2px, rgb(255 0 0 / 0%) 2px, rgba(255, 255, 255, 0) 10px);
 }
 
 #evento-info dt {
     font-weight: bold;
+}
+
+#evento-info dd {
+    white-space: pre-wrap;
 }
 
 


### PR DESCRIPTION
Riparato il fatto che visualizzando un evento senza una immagine, le decorazioni arancioni si sovrapponevano al testo

Ho fatto anche insignificanti migliorie a certi dettagli

closes #186 