### PR TITLE
fix/246-errore-select-eventi

### DIFF
--- a/eventi.php
+++ b/eventi.php
@@ -113,18 +113,29 @@ if ($connectionOk) {
     // Costruzione delle liste di tipo evento
     $lista_tipi_evento_string = '';
     $option = get_content_between_markers($content, 'listaTipiEvento');
+    $anyoneSelected = false;
     foreach ($lista_tipi_evento_array as $tipo_evento) {
-        $selected = ($tipo_evento['Titolo'] == $tipoEvento) ? ' selected' : '';
+        if ($tipo_evento['Titolo'] == $tipoEvento) {
+            $selected = ' selected';
+            $anyoneSelected = true;
+        } else {
+            $selected = '';
+        }
         $lista_tipi_evento_string .= multi_replace($option, [
             '{tipoEvento}' => $tipo_evento['Titolo'],
-            '{selezioneEvento}' => $selected
+            '{selezioneTipoEvento}' => $selected
         ]);
     }
     if ($eventi_senza_tipo != null) {
-        $selected = ($tipoEvento == 'Altri eventi') ? ' selected' : '';
+        if ($tipoEvento == 'Altri eventi') {
+            $selected = ' selected';
+            $anyoneSelected = true;
+        } else {
+            $selected = '';
+        }
         $lista_tipi_evento_string .= multi_replace($option, [
             '{tipoEvento}' => 'Altri eventi',
-            '{selezioneEvento}' => $selected
+            '{selezioneTipoEvento}' => $selected
         ]);
     }
 
@@ -179,6 +190,7 @@ if ($connectionOk) {
             'messaggioFiltri' => $messaggioFiltri
         ]),
         [
+            '{selezioneTipoEventoDefault}' => $anyoneSelected ? '' : ' selected',
             '{data}' => $data,
         ]
     );

--- a/template/eventi.html
+++ b/template/eventi.html
@@ -11,8 +11,8 @@
     <div>
         <label for="tipoEvento">Filtra per tipo</label>
         <select id="tipoEvento" name="tipoEvento">
-            <option value="" selected>Tutti gli eventi</option>
-            {listaTipiEvento}<option value="{tipoEvento}"{selezioneEvento}>{tipoEvento}</option>
+            <option value=""{selezioneTipoEventoDefault}>Tutti gli eventi</option>
+            {listaTipiEvento}<option value="{tipoEvento}"{selezioneTipoEvento}>{tipoEvento}</option>
             {/listaTipiEvento}
         </select>
     </div>


### PR DESCRIPTION
in realtà l'errore c'era sempre, in ogni caso venisse applicato un filtro, il "selected" della voce "Tutti gli eventi" era fissato nel codice html. Così dovrebbe essere corretto.